### PR TITLE
Added the serializer to enable a user to view products that other use…

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -42,7 +42,7 @@ export default function Profile() {
       </CardLayout>
       <CardLayout title="Products recommended to you" width="is-full">
         <div className="columns is-multiline">
-          {profile.recommendations?.map((recommendation) => (
+          {profile.recommended_to_me?.map((recommendation) => (
             <ProductCard
               product={recommendation.product}
               key={recommendation.product.id}


### PR DESCRIPTION
This PR adds the ability for users to see products that have been recommended to them on their profile page.

### What changed:
Added a [recommended_to_me] field to the profile serializer.
Now, when you view your profile, you’ll see both:

Products you’ve recommended to others ([recommends]
Products that other users have recommended to you ([recommended_to_me]

### How it works:
- The backend grabs all [Recommendation] objects where you are the recipient and sends them in the profile response.
- Frontend can now display a "Recommended Items" section for stuff people have suggested to you.

Let me know if you spot any issues or want to tweak the display!

